### PR TITLE
Fix Japanese description

### DIFF
--- a/translations/ja/info/task_description.html
+++ b/translations/ja/info/task_description.html
@@ -62,7 +62,7 @@ checkio() == 0
     <strong>事前条件: </strong>
     0 &le; len(args) &le; 20<br>
     all(-100 &lt; x &lt; 100 for x in args)<br>
-    all(isinstance(x, (int, float) 100 for x in args)
+    all(isinstance(x, (int, float)) for x in args)
 </p>
 
 <div class="facts for_info_only">


### PR DESCRIPTION
There was a typo in Japanese description. Last condition’s syntax
was invalid and included an unnecessary magic number. Altered to
match the condition in the original (English) description.